### PR TITLE
Implemented Board Identification

### DIFF
--- a/CAN_Message_Handler/Accessory.cpp
+++ b/CAN_Message_Handler/Accessory.cpp
@@ -4,7 +4,7 @@
 
 #define BLINK_RATE 0.5
 
-Accessory::Accessory(PinName pin, int initialState, bool blinks, int id, string name) : accessory(pin){
+Accessory::Accessory(PinName pin, int initialState, bool blinks, int id, int board, string name) : accessory(pin){
     Serial pc(USBTX, USBRX);
     pc.printf("Intializing %s to default state %s\n", name.c_str(), initialState ? "ON" : "OFF");
     wait(0.01); //This is here to prevent Serial output from getting garbled up. (And so we can remove it later on and claim that we improved load speeds by 50%)
@@ -17,6 +17,7 @@ Accessory::Accessory(PinName pin, int initialState, bool blinks, int id, string 
     this->blinks = blinks;
     this->id = id;
     this->name = name;
+    this->board = board;
 }
 
 void Accessory::updateState(int newState) {

--- a/CAN_Message_Handler/Accessory.h
+++ b/CAN_Message_Handler/Accessory.h
@@ -5,13 +5,14 @@
 
 class Accessory {
   public:
-    Accessory(PinName pin, int initialState, bool blinks, int id, string name = "no name");
+    Accessory(PinName pin, int initialState, bool blinks, int id, int board, string name = "no name");
     int currentState;
     bool blinks;
     void updateState(int newState);
     void blink();
     int id;
     string name;
+    int board;
   private:
     DigitalOut accessory;
     Ticker t;

--- a/CAN_Message_Handler/CanHandler.cpp
+++ b/CAN_Message_Handler/CanHandler.cpp
@@ -8,16 +8,22 @@ CAN can(PA_11, PA_12); // CAN pins
 Serial pc(USBTX, USBRX);
 
 // Initializing all accessories; need proper pinout
-Accessory headlights(PB_0, 0, true, 0, "headlights");
-Accessory breaklights(PB_7, 0, false, 1, "breaklights");
-Accessory horn(PB_6, 0, true, 2, "horn");
-Accessory hazards(LED1, 1, true, 3, "hazards");
-Accessory rightInd(PB_5, 0, true, 4, "right indicator");
-Accessory leftInd(PB_5, 0, true, 5, "left indicator");
-Accessory wipers(PB_5, 0, false, 6, "wipers");
-Accessory something_else_i_dont_know(PB_0, 0, false, 7);
+Accessory headlights(PB_0, 0, true, 0, 0, "headlights");
+Accessory breaklights(PB_7, 0, false, 1, 0, "breaklights");
+Accessory horn(PB_6, 0, true, 2, 0, "horn");
+Accessory hazards(LED1, 1, true, 3, 0, "hazards");
+Accessory rightInd(PB_5, 0, true, 4, 0, "right indicator");
+Accessory leftInd(PB_5, 0, true, 5, 0, "left indicator");
+Accessory wipers(PB_5, 0, false, 6, 0, "wipers");
+Accessory something_else_i_dont_know(PB_0, 0, false, 7, 0, "other");
 //accessories are in pointer array because Ticker are not allowed to be copied. It took me 4 hours to fix this bug.
 Accessory *accessories[] = {&hazards, &rightInd, &leftInd, &wipers, &headlights, &breaklights, &horn};
+
+// Board Identifier
+DigitalIn b_id0(PA_3);
+DigitalIn b_id1(PA_1);
+DigitalIn b_id2(PA_0);
+int board = (((b_id0 << 1)| b_id2) << 1)| b_id2;
 
 //constructor
 CanHandler::CanHandler() {
@@ -42,7 +48,7 @@ void CanHandler::handleMessages() {
     for (int i = 0; i < (int)(sizeof(accessories)/sizeof(*accessories)); i++) {
       pc.printf("\nchecking accessory - %s at bit %d\n", accessories[i]->name.c_str(), i);
       int msgState = (msg.data[0] & (1 << accessories[i]->id)) >> accessories[i]->id;
-      if (msgState != accessories[i]->currentState) {
+      if (msgState != accessories[i]->currentState & board == accessories[i]->board) {
         accessories[i]->updateState(msgState);
       }
     }


### PR DESCRIPTION
Added board attribute to each accessory.
CAN Handler checks if board matches the accessory board before updating accessory state/mode.